### PR TITLE
Fix compilation warnings/errors in smux, tip, virus

### DIFF
--- a/src/cmd/smux/retro/smux.c
+++ b/src/cmd/smux/retro/smux.c
@@ -73,9 +73,9 @@ int rx_link_data()
     static unsigned char phase = 0;
     static unsigned int pos = 0;
     char inch[2];
-    int res;
+//    int res;
 
-    res = read(0, inch, 1);
+    /*res =*/ read(0, inch, 1);
 
     switch(phase) {
     case 0:

--- a/src/cmd/tip/aculib/hayes.c
+++ b/src/cmd/tip/aculib/hayes.c
@@ -120,7 +120,9 @@ void error_rep(c)
  */
 void goodbye()
 {
+#ifdef DEBUG
     int len;
+#endif
     int zero = 0;
     long llen;
     char c;
@@ -141,8 +143,8 @@ void goodbye()
 #endif
         sleep(1);
         ioctl(FD, FIONREAD, &llen);
-        len = llen;
 #ifdef DEBUG
+        len = llen;
         printf("goodbye1: len=%d -- ", len);
         int rlen = read(FD, dumbuf, min(len, DUMBUFLEN));
         dumbuf[rlen] = '\0';

--- a/src/cmd/tip/tip.c
+++ b/src/cmd/tip/tip.c
@@ -515,10 +515,10 @@ void pwrite(fd, buf, n)
     register int n;
 {
     //register int i;
-    register char *bp;
+//    register char *bp;
     extern int errno;
 
-    bp = buf;
+//    bp = buf;
     //for (i = 0; i < n; i++) {
     //    *bp = partab[(*bp) & 0177];
     //    bp++;

--- a/src/cmd/virus/virus.c
+++ b/src/cmd/virus/virus.c
@@ -88,6 +88,8 @@ char *vi_Version =
 #include "lib/strlcat.c"
 #include "lib/strlcpy.c"
 
+#include <strings.h>
+
 #ifndef TRUE
 #define TRUE			((int)1)
 #define FALSE			((int)0)
@@ -2226,15 +2228,15 @@ static void Hit_Return(void)
 //----- Synchronize the cursor to Dot --------------------------
 static void sync_cursor(Byte * d, int *row, int *col)
 {
-	Byte *beg_cur, *end_cur;	// begin and end of "d" line
-	Byte *beg_scr, *end_scr;	// begin and end of screen
+	Byte *beg_cur/*, *end_cur*/;	// begin and end of "d" line
+	Byte /**beg_scr,*/ *end_scr;	// begin and end of screen
 	Byte *tp;
 	int cnt, ro, co;
 
 	beg_cur = begin_line(d);	// first char of cur line
-	end_cur = end_line(d);	// last char of cur line
+	/*end_cur =*/ end_line(d);	// last char of cur line
 
-	beg_scr = end_scr = screenbegin;	// first char of screen
+	/*beg_scr =*/ end_scr = screenbegin;	// first char of screen
 	end_scr = end_screen();	// last char of screen
 
 	if (beg_cur < screenbegin) {
@@ -3123,9 +3125,9 @@ static Byte *text_yank(Byte * p, Byte * q, int dest)	// copy text into a registe
 static Byte what_reg(void)
 {
 	Byte c;
-	int i;
+//	int i;
 
-	i = 0;
+//	i = 0;
 	c = 'D';			// default to D-reg
 	if (0 <= YDreg && YDreg <= 25)
 		c = 'a' + (Byte) YDreg;
@@ -3526,7 +3528,7 @@ static int file_size(Byte * fn) // what is the byte size of "fn"
 	struct stat st_buf;
 	int cnt, sr;
 
-	if (fn == 0 || strlen(fn) <= 0)
+	if (fn == 0 || strlen((const char*)fn) <= 0)
 		return (-1);
 	cnt = -1;
 	sr = stat((char *) fn, &st_buf);	// see if file exists


### PR DESCRIPTION
Fix compilation warnings/errors primarily due to unused variables.
