### PR TITLE
Improve variable initialization in Smaller C

### DIFF
--- a/src/cmd/smlrc/smlrc.c
+++ b/src/cmd/smlrc/smlrc.c
@@ -5805,7 +5805,7 @@ int InitScalar(int synPtr, int tok)
   {
     // TBD??? truncate values for types smaller than int (e.g. char and short),
     // so they are always in range?
-    GenIntData(elementSz, exprVal);
+    GenIntData(elementSz, stack[0][1]);
   }
   else if (elementSz == SizeOfWord + 0u && stack[sp - 1][0] == tokIdent)
   {


### PR DESCRIPTION
Improvements:
- support initialization of multidimensional arrays
- support initialization of structures
- support initialization of structures and arrays inside functions
- support static inside functions

Notes:
- Only fully-bracketed (sic) initialization of arrays is supported.
- && and || have been partially replaced with & and | to slightly reduce
  code size when self compiling for DOS using -seg16.
