### PR TITLE
Smaller C: Improve pointer initialization

### DIFF
--- a/src/cmd/smlrc/cgmips.c
+++ b/src/cmd/smlrc/cgmips.c
@@ -3,13 +3,13 @@ Copyright (c) 2012-2014, Alexey Frunze
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met: 
+modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution. 
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -23,7 +23,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies, 
+of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
@@ -131,15 +131,19 @@ void GenStartAsciiString(void)
   printf2("\t.ascii\t");
 }
 
-void GenAddrData(int Size, char* Label)
+void GenAddrData(int Size, char* Label, int ofs)
 {
+  ofs = truncInt(ofs);
   if (Size == 1)
     printf2("\t.byte\t");
   else if (Size == 2)
     printf2("\t.half\t");
   else if (Size == 4)
     printf2("\t.word\t");
-  GenPrintLabel(Label); puts2("");
+  GenPrintLabel(Label);
+  if (ofs)
+    printf2(" %+d", ofs);
+  puts2("");
 }
 
 #define MipsInstrNop    0x00

--- a/src/cmd/smlrc/cgx86.c
+++ b/src/cmd/smlrc/cgx86.c
@@ -3,13 +3,13 @@ Copyright (c) 2012-2014, Alexey Frunze
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met: 
+modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution. 
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -23,7 +23,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies, 
+of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
@@ -237,8 +237,9 @@ void GenStartAsciiString(void)
   printf2("\tdb\t");
 }
 
-void GenAddrData(int Size, char* Label)
+void GenAddrData(int Size, char* Label, int ofs)
 {
+  ofs = truncInt(ofs);
 #ifdef CAN_COMPILE_32BIT
   if (OutputFormat == FormatSegHuge)
   {
@@ -256,7 +257,10 @@ void GenAddrData(int Size, char* Label)
   else if (Size == 4)
     printf2("\tdd\t");
 #endif
-  GenPrintLabel(Label); puts2("");
+  GenPrintLabel(Label);
+  if (ofs)
+    printf2(" %+d", ofs);
+  puts2("");
   if (!isdigit(*Label))
     GenAddGlobal(Label, 2);
 }


### PR DESCRIPTION
The following global/static pointer initialization should now work:

static char\* p1 = "abc" + 1;
static char\* p2 = "abc" - 1;
static char\* p3 = 1 + "abc";
static int a333[3][3][3];
static int\* pa333_111 = &a333[1][1][1];

Other seemingly (and in fact actually) functionality preserving changes
are only to reduce code size when self compiling for DOS using -seg16.
Improvements and fixes require space, sigh.
