### PR TITLE
Update emg man page.

### DIFF
--- a/src/cmd/emg/emg.1
+++ b/src/cmd/emg/emg.1
@@ -3,7 +3,7 @@
 .\" Basic emg man page.
 .\" As both Ersatz Emacs and Mg are Public Domain, emg is also Public Domain.
 .\"
-.Dd March 23, 2014
+.Dd June 17, 2014
 .Os
 .Dt EMG 1
 .Sh NAME
@@ -14,12 +14,12 @@
 .Op Ar
 .Sh DESCRIPTION
 .Nm ,
-or Ersatz Mg, is an Emacs-like text editor designed for memory-constrained
-environments.
+or Ersatz Mg, is an Emacs-like text editor designed for RetroBSD
+and other memory-constrained environments.
 .Nm
-was originally created to fit into an operating environment of 96K of RAM, and
-one in which Mg did not fit and Ersatz Emacs did not build.
-By combining parts of each, a working editor was created.
+was originally created to fit into an operating environment of 96K of RAM,
+and one in which Mg did not fit and Ersatz Emacs did not build.
+By combining parts of each a working editor was created.
 .Pp
 When invoked without file arguments,
 .Nm
@@ -37,13 +37,17 @@ is also Public Domain.
 .Sh FILES
 There is a chart of key bindings in
 .Pa /usr/local/share/doc/emg/emg.keys .
-Consulting this file is a must, as
+Consulting this file is a must.
+While
 .Nm
-does not guarantee keybindings to be identical to other Emacs implementations.
+strives to maintain compatibility with larger Emacs implementations,
+there may be features intentionally left unimplemented in order to keep
+.Nm
+as small as possible.
 .Sh AUTHORS
 .Nm
-is a combination of Ersatz Emacs and Mg and therefore all authors for both
-deserve credit.
+is a combination of Ersatz Emacs and Mg and therefore all authors
+for both deserve credit.
 Ersatz Emacs and Mg were combined by
 .An Brian Callahan Aq Mt bcallah@openbsd.org
 to create


### PR DESCRIPTION
A small update for the emg man page: note that emg is trying to stay finger-compatible (and visually compatible) with big GNU Emacs and make a direct plug for RetroBSD.
