### PR TITLE
Smaller C: Improve initialization of variables

### DIFF
--- a/src/cmd/smlrc/cgmips.c
+++ b/src/cmd/smlrc/cgmips.c
@@ -483,7 +483,6 @@ void GenJumpUncond(int label)
 
 extern int GenWreg; // GenWreg is defined below
 
-#ifndef USE_SWITCH_TAB
 STATIC
 void GenJumpIfEqual(int val, int label)
 {
@@ -495,7 +494,6 @@ void GenJumpIfEqual(int val, int label)
                          TEMP_REG_B, 0,
                          MipsOpNumLabel, label);
 }
-#endif
 
 STATIC
 void GenJumpIfZero(int label)


### PR DESCRIPTION
- throw away data of string literals inside sizeof, e.g.
    sizeof "a"
    sizeof("a"+1)
- support minimally and inconsistently bracketed (sic)
  initialization, e.g.:
    int y[4][3] = { 1, 3, 5, 2, 4, 6, 3, 5, 7 };
    struct { int a[3], b; } w[] = { { 1 }, 2 };
- scalar initializers can be optionally enclosed in
  braces, e.g.:
    int i1 = { 1 };