### PR TITLE
Fix build for gcc >= 5.0

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -13,9 +13,10 @@ else
     HOSTINC     += -I/usr/include/i386-linux-gnu
 endif
 
-CFLAGS		+= -nostdinc -fno-builtin -g -Werror -Wall -DCROSS -I. $(HOSTINC) \
-                   -I$(TOPSRC)/include -I$(TOPSRC)/src/cmd/ar \
-                   -I$(TOPSRC)/src/cmd/as
+CFLAGS		+= -std=gnu89 -fno-builtin -g -Werror -Wall -DCROSS -I. \
+                   -idirafter $(TOPSRC)/include \
+		   -idirafter $(TOPSRC)/src/cmd/ar \
+                   -idirafter $(TOPSRC)/src/cmd/as
 LDFLAGS         += -g
 
 AR_OBJS         = ar.o append.o archive.o contents.o delete.o extract.o \

--- a/src/cmd/awk/Makefile
+++ b/src/cmd/awk/Makefile
@@ -37,7 +37,7 @@ lint:
 			egrep -v '^(error|free|malloc)'
 
 proctab.c:	proc.c token.h awk.h
-		cc -Wall -Werror -o proc proc.c
+		cc -std=gnu89 -Wall -Werror -o proc proc.c
 		./proc > proctab.c
 
 clean:


### PR DESCRIPTION
gcc 5.0 defaults to -std=gnu11 meaning code which relies on implicit
ints will no longer compile. Passing -std=gnu89 restores the default
but causes problems because the system headers are written in gnu11.
Using -idirafter instead of -nostdinc resolves all problems and should
be compatible with old GCC versions (and clang).