### PR TITLE
Smaller C: improve prologue on MIPS

### DIFF
--- a/src/cmd/smlrc/cgmips.c
+++ b/src/cmd/smlrc/cgmips.c
@@ -541,7 +541,7 @@ void GenUpdateFrameSize(void)
 STATIC
 void GenFxnProlog(void)
 {
-  if (CurFxnParamCntMax)
+  if (CurFxnParamCntMin && CurFxnParamCntMax)
   {
     int i, cnt = CurFxnParamCntMax;
     if (cnt > 4)


### PR DESCRIPTION
Functions defined as 'type f()' now don't store A0-A3
on the stack just as functions defined as 'type f(void)'.