### PR TITLE
insert definitions of INT in some functions

### DIFF
--- a/src/share/zoneinfo/zdump.c
+++ b/src/share/zoneinfo/zdump.c
@@ -26,6 +26,7 @@ static void
 show(zone, t, v)
 char *	zone;
 time_t	t;
+int v;
 {
 	struct tm *		tmp;
 

--- a/src/share/zoneinfo/zic.c
+++ b/src/share/zoneinfo/zic.c
@@ -309,6 +309,8 @@ static void
 eats(name, num, rname, rnum)
 char *	name;
 char *	rname;
+int num;
+int rnum;
 {
 	filename = name;
 	linenum = num;
@@ -319,6 +321,7 @@ char *	rname;
 static void
 eat(name, num)
 char *	name;
+int num;
 {
 	eats(name, num, (char *) NULL, -1);
 }
@@ -653,6 +656,7 @@ static long
 gethms(string, errstring, signable)
 char *	string;
 char *	errstring;
+int signable;
 {
 	int	hh, mm, ss, sign;
 
@@ -687,6 +691,7 @@ char *	errstring;
 static void
 inrule(fields, nfields)
 register char **	fields;
+int nfields;
 {
 	struct rule	r;
 
@@ -713,6 +718,7 @@ register char **	fields;
 static int
 inzone(fields, nfields)
 register char **	fields;
+int nfields;
 {
 	register int	i;
 	char		buf[132];
@@ -743,8 +749,9 @@ register char **	fields;
 }
 
 static int
-inzcont(fields, nfields)
+inzcont(fields,  nfields)
 register char **	fields;
+int nfields;
 {
 	if (nfields < ZONEC_MINFIELDS || nfields > ZONEC_MAXFIELDS) {
 		error("wrong number of fields on Zone continuation line");
@@ -756,6 +763,8 @@ register char **	fields;
 static int
 inzsub(fields, nfields, iscont)
 register char **	fields;
+int nfields;
+int  iscont;
 {
 	register char *	cp;
 	struct zone	z;
@@ -826,6 +835,7 @@ error("Zone continuation line end time is not after end time of previous line");
 static void
 inlink(fields, nfields)
 register char **	fields;
+int  nfields;
 {
 	struct link	l;
 
@@ -1055,6 +1065,7 @@ char *	name;
 static void
 outzone(zpfirst, zonecount)
 struct zone *	zpfirst;
+int zonecount;
 {
 	register struct zone *		zp;
 	register struct rule *		rp;
@@ -1200,6 +1211,7 @@ addtt(starttime, addtype(startoff, startbuf, startisdst));
 static void
 addtt(starttime, type)
 time_t	starttime;
+int type;
 {
 	if (timecnt != 0 && type == types[timecnt - 1])
 		return;	/* easy enough! */
@@ -1216,6 +1228,7 @@ static int
 addtype(gmtoff, abbr, isdst)
 long	gmtoff;
 char *	abbr;
+int isdst;
 {
 	register int	i, j;
 
@@ -1251,6 +1264,7 @@ char *	abbr;
 
 static int
 yearistype(year, type)
+int year;
 char *	type;
 {
 	char	buf[BUFSIZ];
@@ -1276,7 +1290,7 @@ char *	type;
 }
 
 static int
-lowerit(a)
+lowerit(int a)
 {
 	return (isascii(a) && isupper(a)) ? tolower(a) : a;
 }
@@ -1538,7 +1552,7 @@ char *	name;
 }
 
 static long
-eitol(i)
+eitol(int i)
 {
 	long	l;
 

--- a/tools/kconfig/mkioconf.c
+++ b/tools/kconfig/mkioconf.c
@@ -36,8 +36,7 @@
 /*
  * build the ioconf.c file
  */
-static void
-service_ioconf(fp)
+static void service_ioconf(fp)
     register FILE *fp;
 {
     register struct device *dp;
@@ -56,8 +55,7 @@ service_ioconf(fp)
     fprintf(fp, "    { 0 }\n};\n");
 }
 
-static char *
-wnum(num)
+static char *wnum(int num)
 {
     if (num == QUES || num == UNKNOWN)
         return ("?");


### PR DESCRIPTION
While compiling on clean lubuntu 16.04.1 lts (Virtualbox) as described in http://retrobsd.org/wiki/doku.php/doc/install
some errors occured:

.../retrobsd/src/share/zoneinfo/zdump.c   :
zdump.c:26:1: error: type of ‘v’ defaults to ‘int’ [-Werror=implicit-int]
 show(zone, t, v)
 ^
cc1: all warnings being treated as errors
///// numerous, but compiler stops on the first

.../retrobsd/tools/kconfig$ ls mkioconf.c  :+1
mkioconf.c: In function ‘wnum’:
mkioconf.c:58:14: error: type of ‘num’ defaults to ‘int’ [-Werror=implicit-int]
static char *wnum(num)
              ^
cc1: all warnings being treated as errors

So, kconfig and zdump were not created/
This commit  difines the types of some variables in "visible" form:
void function(var)     =>   void function (int var)