### PR TITLE
Retern to legacy implement for expr(1) etc.

### DIFF
--- a/src/libc/stdio/doprnt.c
+++ b/src/libc/stdio/doprnt.c
@@ -171,19 +171,8 @@ reswitch:	switch (c = *fmt++) {
 			break;
 
 		case 'D':
-			s = va_arg (ap, const unsigned char*);
-			if (! width)
-				width = 16;
-			if (sharpflag)
-				padding = ':';
-			while (width--) {
-				c = *s++;
-				PUTC (mkhex (c >> 4));
-				PUTC (mkhex (c));
-				if (width)
-					PUTC (padding);
-			}
-			break;
+			lflag=1;
+			/* FALLTHROUGH */
 
 		case 'd':
 		case 'i':


### PR DESCRIPTION
At BSD legacy printf format "%D" mean "%ld".
But RetroBSD has original implementation for print out some hex value.

expr(1) use "%D" as "%ld", so expr(1) is broken.

See also http://retrobsd.org/viewtopic.php?f=7&t=37519