### PR TITLE
Update gettytab to change the default login banner from "2.11 BSD UNI…

### DIFF
--- a/etc/gettytab
+++ b/etc/gettytab
@@ -16,7 +16,7 @@
 # entries, and in cases where getty is called with no table name
 #
 default:\
-	:ap:im=\r\n\r\n2.11 BSD UNIX (%h) (%t)\r\n\r\r\n\r:sp#1200:
+	:ap:im=\r\n\r\nRetroBSD (%h) (%t)\r\n\r\r\n\r:sp#1200:
 
 #
 # Fixed speed entries


### PR DESCRIPTION
…X" to "RetroBSD"