### PR TITLE
Add cmn_err() from SysV and Coherent.

### DIFF
--- a/sys/include/cmn_err.h
+++ b/sys/include/cmn_err.h
@@ -1,0 +1,12 @@
+#ifndef _SYS_CMN_ERR_H
+#define _SYS_CMN_ERR_H
+
+#define CE_CONT   0 /* continuation */
+#define CE_NOTICE 1 /* notice */
+#define CE_WARN   2 /* warning */
+#define CE_PANIC  3 /* panic */
+
+extern void cmn_err(int level, char *fmt, ...);
+extern void xcmn_err(int level, char **fmtp);
+
+#endif /* _SYS_CMN_ERR_H */

--- a/sys/kernel/subr_prf.c
+++ b/sys/kernel/subr_prf.c
@@ -13,6 +13,7 @@
 #include <sys/reboot.h>
 #include <sys/systm.h>
 #include <sys/syslog.h>
+#include <sys/cmn_err.h>
 
 #define TOCONS  0x1
 #define TOTTY   0x2
@@ -24,6 +25,11 @@
  * call to panic.
  */
 char    *panicstr;
+
+/*
+ * Boot options for panic
+ */
+int bootopt = RB_HALT | RB_DUMP;
 
 /*
  * Print a character on console or users terminal.
@@ -564,8 +570,6 @@ void
 panic(s)
     char *s;
 {
-    int bootopt = RB_HALT | RB_DUMP;
-
     if (panicstr) {
         bootopt |= RB_NOSYNC;
     } else {
@@ -573,4 +577,51 @@ panic(s)
     }
     printf ("panic: %s\n", s);
     boot (rootdev, bootopt);
+}
+
+void
+cmn_err(int level, char *fmt, ... )
+{
+	xcmn_err(level, &fmt);
+}
+
+void
+xcmn_err(int level, char **fmtp)
+{
+	register char	*fmt = *fmtp;
+	register u_int	nextarg = (u_int) ((u_int *)fmtp + 1);
+
+	switch (level) {
+		case CE_CONT :
+			printf(fmt, nextarg) ;
+			break ;
+
+		case CE_NOTE :
+			printf("NOTICE: %s\n", fmt) ;
+			break ;
+
+		case CE_WARN :
+			printf("WARNING: %s\n", fmt) ;
+			break ;
+
+		case CE_PANIC :
+			switch (panic_level) {
+				case 0 :
+					panic_level = 1 ;
+					printf("PANIC: %s\n", fmt) ;
+					break;
+
+				case 1 :
+					panic_level = 2 ;
+					printf("DOUBLE PANIC: %s\n", fmt) ;
+                    bootopt |= RB_NOSYNC;
+					break;
+
+				default :
+					panic_level = 3 ;
+			}
+        boot(rootdev, bootopt);
+		default:
+			cmn_err(CE_PANIC, "unknown level: cmn_err(level=%d, msg=\"%s\")", level, fmt);
+	}
 }

--- a/sys/kernel/subr_prf.c
+++ b/sys/kernel/subr_prf.c
@@ -32,6 +32,11 @@ char    *panicstr;
 int bootopt = RB_HALT | RB_DUMP;
 
 /*
+ * The panic level - needed by xcmn_err()
+ */
+static int panic_level = 0;
+
+/*
  * Print a character on console or users terminal.
  * If destination is console then the last MSGBUFS characters
  * are saved in msgbuf for inspection later.


### PR DESCRIPTION
SysV and Coherent (a Unix clone) do not use the panic() function. Instead, they use cmn_err(), which also supports printing warnings from the kernel, notices, and kernel panics. The code has been slightly modified from the original, so it can be built under RetroBSD.