### PR TITLE
Import __floatunsidf from FreeBSD to solve #98

### DIFF
--- a/src/libc/runtime/Makefile
+++ b/src/libc/runtime/Makefile
@@ -43,7 +43,8 @@ OBJS            = adddf3.o \
                   truncdfsf2.o \
                   udivdi3.o \
                   udivmoddi4.o \
-                  umoddi3.o
+                  umoddi3.o \
+		  floatunsidf.o
 
 runtime.a:      ${OBJS}
 		@echo "buiding runtime.a"

--- a/src/libc/runtime/floatunsidf.c
+++ b/src/libc/runtime/floatunsidf.c
@@ -1,0 +1,37 @@
+//===-- lib/floatunsidf.c - uint -> double-precision conversion ---*- C -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements unsigned integer to double-precision conversion for the
+// compiler-rt library in the IEEE-754 default round-to-nearest, ties-to-even
+// mode.
+//
+//===----------------------------------------------------------------------===//
+
+#define DOUBLE_PRECISION
+#include "fp_lib.h"
+
+fp_t __floatunsidf(unsigned int a) {
+    
+    const int aWidth = sizeof a * CHAR_BIT;
+    
+    // Handle zero as a special case to protect clz
+    if (a == 0) return fromRep(0);
+    
+    // Exponent of (fp_t)a is the width of abs(a).
+    const int exponent = (aWidth - 1) - __builtin_clz(a);
+    rep_t result;
+    
+    // Shift a into the significand field and clear the implicit bit.
+    const int shift = significandBits - exponent;
+    result = (rep_t)a << shift ^ implicitBit;
+    
+    // Insert the exponent
+    result += (rep_t)(exponent + exponentBias) << significandBits;
+    return fromRep(result);
+}


### PR DESCRIPTION
This pulls in __floatunsidf from the FreeBSD source tree to add conversion of unsigned integer to double float to the libc runtime. This is needed for compilation of code that uses `sin()` etc for mips32. Fixes #98