### PR TITLE
Add additional size checks to a.out binaries

### DIFF
--- a/sys/kernel/exec_aout.c
+++ b/sys/kernel/exec_aout.c
@@ -68,9 +68,12 @@ int exec_aout_check(struct exec_params *epp)
 
     /*
      * Allocate core at this point, committed to the new image.
-     * TODO: What to do for errors?
      */
-    exec_estab(epp);
+    error = exec_estab(epp);
+    if (error) {
+        DEBUG("exec_estab returned error=%d\n", error);
+        return error;
+    }
 
     /* read in text and data */
     DEBUG("reading a.out image\n");

--- a/sys/kernel/exec_subr.c
+++ b/sys/kernel/exec_subr.c
@@ -2,6 +2,7 @@
 #include <sys/systm.h>
 #include <sys/map.h>
 #include <sys/inode.h>
+#include <sys/types.h>
 #include <sys/user.h>
 #include <sys/proc.h>
 #include <sys/buf.h>
@@ -218,6 +219,13 @@ int exec_estab(struct exec_params *epp)
      * Try out for overflow
      */
     if (epp->text.len + epp->data.len + epp->heap.len + epp->stack.len > MAXMEM)
+        return ENOMEM;
+
+    /*
+     * Check for bss and data addresses over limit
+    */
+    if (epp->data.vaddr + epp->data.len > (caddr_t)USER_DATA_END
+        || epp->bss.vaddr+epp->bss.len > (caddr_t)USER_DATA_END)
         return ENOMEM;
 
     if (roundup((unsigned)epp->data.vaddr + epp->data.len, NBPW) != roundup((unsigned)epp->bss.vaddr, NBPW)) {


### PR DESCRIPTION
This prevents crashes if sections with invalid addresses are attempted to be created.

Specifically, when trying to get ccom to run, the .bss section had addresses above the top of RAM. This check allows a more graceful recovery than crashing the whole system.