### PR TITLE
Updated makefiles to be compatible with parallel buiids

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,22 @@ FSUTIL		= tools/fsutil/fsutil
 TOPSRC       = $(shell pwd)
 CONFIG       = $(TOPSRC)/tools/kconfig/kconfig
 
-all:
-		$(MAKE) -C tools
+all: tools
+		$(MAKE) kernel
 		$(MAKE) -C src
 		#$(MAKE) -C lib
 		$(MAKE) -C src install
-		$(MAKE) kernel
 		$(MAKE) fs
 
-kernel:         $(CONFIG)
+.PHONY: kernel
+
+kernel: $(CONFIG) tools
 		$(MAKE) -C sys/pic32 all
+
+.PHONY: tools
+
+tools:
+		$(MAKE) -C tools
 
 fs:             sdcard.img
 
@@ -58,7 +64,7 @@ $(FSUTIL):
 		cd tools/fsutil; $(MAKE)
 
 $(CONFIG):
-		make -C tools/kconfig
+		$(MAKE) -C tools/kconfig
 
 clean:
 		rm -f *~

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,12 +8,16 @@ include $(TOPSRC)/target.mk
 
 # Programs that live in subdirectories, and have makefiles of their own.
 #
-SUBDIR		= startup-$(MACHINE) libc libm libutil libtermlib libcurses \
-                  libvmf libwiznet libreadline libgpanel share cmd games man
+LIBS		= startup-$(MACHINE) libc libm libutil libtermlib libcurses \
+                  libvmf libwiznet libreadline libgpanel 
+SUBDIR		= share cmd games man
 
-all:		$(SUBDIR)
+all:		$(LIBS) $(SUBDIR)
 
-$(SUBDIR):	FRC
+$(LIBS):	FRC
+	$(MAKE) -C $@
+
+$(SUBDIR):	FRC | $(LIBS)
 		$(MAKE) -C $@
 
 FRC:
@@ -26,3 +30,4 @@ install:        elf32-mips.ld
 clean:
 		rm -f a.out core *.s *.o *.a *~
 		-for i in $(SUBDIR); do $(MAKE) -C $$i clean; done
+		-for i in $(LIBS); do $(MAKE) -C $$i clean; done

--- a/src/cmd/Makefile
+++ b/src/cmd/Makefile
@@ -83,8 +83,7 @@ FRC:
 
 # bc egrep expr
 %.c: %.y
-		$(YACC) $(YFLAGS) $<
-		-/bin/mv y.tab.c $@
+		$(YACC) $(YFLAGS) -o $@ $<
 
 $(SCRIPT):
 		install -c $@.sh $@

--- a/sys/pic32/Makefile
+++ b/sys/pic32/Makefile
@@ -3,12 +3,15 @@
 #
 SUBDIR		= explorer16 olimex
 
-default:
 
-all:
-		-for i in $(SUBDIR); do ${MAKE} -C $$i all; done
+all: subdirs
 
-install:
+.PHONY: subdirs $(SUBDIR)
+
+subdirs: $(SUBDIR)
+
+$(SUBDIR):
+	$(MAKE) -C $@
 
 clean:
 		-for i in $(SUBDIR); do ${MAKE} -C $$i clean; done

--- a/sys/pic32/Makefile.kconf
+++ b/sys/pic32/Makefile.kconf
@@ -44,25 +44,35 @@ SYSTEM_OBJ      = startup.o ${OBJS} ioconf.o
 ifeq (devcfg.c,$(wildcard devcfg.c))
     SYSTEM_OBJ  += devcfg.o
 endif
-SYSTEM_DEP      = Makefile ioconf.c machine sys .deps ${SYSTEM_OBJ}
+SYSTEM_DEP      = Makefile ioconf.c | machine sys .deps
 SYSTEM_LD_HEAD  = sh ../newvers.sh > vers.c; ${CC} $(CFLAGS) -c vers.c; rm -f $@
 SYSTEM_LD       = -@echo ${LD} ${LDFLAGS} '$${SYSTEM_OBJ}' vers.o -o $@; \
                   ${LD} ${LDFLAGS} ${SYSTEM_OBJ} vers.o -o $@
 SYSTEM_LD_TAIL  = ${SIZE} $@; \
                   $(OBJCOPY) -O ihex $@ $(basename $@).hex; \
                   $(OBJCOPY) -O binary -R .boot -R .config $@ $(basename $@).bin; \
+				  $(OBJCOPY) -O binary --only-section .boot $@ boot.bin; \
                   $(OBJDUMP) -d -S $@ > $(basename $@).dis; \
                   $(NM) -n $@ > $(basename $@).nm
 
 %LOAD
 
 clean:
-	rm -rf .deps *.elf *.o *.nm *.dis *.bin machine sys
+	rm -rf *.elf *.o *.nm *.dis *.bin
 
 clean-all: clean
-	rm -f *.h *.hex ioconf.c swap*.c vers.c
+	rm -f *.h *.hex ioconf.c swap*.c vers.c machine sys .deps
 
-reconfig ioconf.c: Config ../../../tools/kconfig/kconfig
+.PHONY: reconfig
+
+reconfig: ioconf.c
+
+swapunix.c: Config ../../../tools/kconfig/kconfig | sys machine
+	../../../tools/kconfig/kconfig Config
+	$(MAKE) clean
+	rm -f *.hex
+
+ioconf.c: Config ../../../tools/kconfig/kconfig | sys machine
 	../../../tools/kconfig/kconfig Config
 	$(MAKE) clean
 	rm -f *.hex
@@ -79,14 +89,14 @@ sys:
 .deps:
 	mkdir .deps
 
-startup.o: ../startup.S
+startup.o: ../startup.S ${SYSTEM_DEP}
 	${COMPILE_S}
 
-ioconf.o: ioconf.c
+ioconf.o: ioconf.c  ${SYSTEM_DEP}
 	${COMPILE_C}
+
+devcfg.o: devcfg.c ${SYSTEM_DEP}
 
 %RULES
 
-ifeq (.deps, $(wildcard .deps))
 -include .deps/*.dep
-endif

--- a/sys/pic32/explorer16/.gitignore
+++ b/sys/pic32/explorer16/.gitignore
@@ -10,3 +10,4 @@ vers.c
 *.h
 ioconf.c
 swapunix.c
+boot.bin

--- a/sys/pic32/explorer16/Makefile
+++ b/sys/pic32/explorer16/Makefile
@@ -105,35 +105,45 @@ SYSTEM_OBJ      = startup.o ${OBJS} ioconf.o
 ifeq (devcfg.c,$(wildcard devcfg.c))
     SYSTEM_OBJ  += devcfg.o
 endif
-SYSTEM_DEP      = Makefile ioconf.c machine sys .deps ${SYSTEM_OBJ}
+SYSTEM_DEP      = Makefile ioconf.c | machine sys .deps
 SYSTEM_LD_HEAD  = sh ../newvers.sh > vers.c; ${CC} $(CFLAGS) -c vers.c; rm -f $@
 SYSTEM_LD       = -@echo ${LD} ${LDFLAGS} '$${SYSTEM_OBJ}' vers.o -o $@; \
                   ${LD} ${LDFLAGS} ${SYSTEM_OBJ} vers.o -o $@
 SYSTEM_LD_TAIL  = ${SIZE} $@; \
                   $(OBJCOPY) -O ihex $@ $(basename $@).hex; \
                   $(OBJCOPY) -O binary -R .boot -R .config $@ $(basename $@).bin; \
+				  $(OBJCOPY) -O binary --only-section .boot $@ boot.bin; \
                   $(OBJDUMP) -d -S $@ > $(basename $@).dis; \
                   $(NM) -n $@ > $(basename $@).nm
 
 unix: unix.elf
 
-unix.elf: ${SYSTEM_DEP} swapunix.o
+unix.elf: ${SYSTEM_DEP} ${SYSTEM_OBJ} swapunix.o
 	${SYSTEM_LD_HEAD}
 	${SYSTEM_LD} swapunix.o
 	${SYSTEM_LD_TAIL}
 
-swapunix.o: swapunix.c
+swapunix.o: swapunix.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
 all: unix
 
 clean:
-	rm -rf .deps *.elf *.o *.nm *.dis *.bin machine sys
+	rm -rf *.elf *.o *.nm *.dis *.bin
 
 clean-all: clean
-	rm -f *.h *.hex ioconf.c swap*.c vers.c
+	rm -f *.h *.hex ioconf.c swap*.c vers.c machine sys .deps
 
-reconfig ioconf.c: Config ../../../tools/kconfig/kconfig
+.PHONY: reconfig
+
+reconfig: ioconf.c
+
+swapunix.c: Config ../../../tools/kconfig/kconfig | sys machine
+	../../../tools/kconfig/kconfig Config
+	$(MAKE) clean
+	rm -f *.hex
+
+ioconf.c: Config ../../../tools/kconfig/kconfig | sys machine
 	../../../tools/kconfig/kconfig Config
 	$(MAKE) clean
 	rm -f *.hex
@@ -150,205 +160,205 @@ sys:
 .deps:
 	mkdir .deps
 
-startup.o: ../startup.S
+startup.o: ../startup.S ${SYSTEM_DEP}
 	${COMPILE_S}
 
-ioconf.o: ioconf.c
+ioconf.o: ioconf.c  ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exec_aout.o: $S/kernel/exec_aout.c
+devcfg.o: devcfg.c ${SYSTEM_DEP}
+
+exec_aout.o: $S/kernel/exec_aout.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exec_conf.o: $S/kernel/exec_conf.c
+exec_conf.o: $S/kernel/exec_conf.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exec_elf.o: $S/kernel/exec_elf.c
+exec_elf.o: $S/kernel/exec_elf.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exec_script.o: $S/kernel/exec_script.c
+exec_script.o: $S/kernel/exec_script.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exec_subr.o: $S/kernel/exec_subr.c
+exec_subr.o: $S/kernel/exec_subr.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-init_main.o: $S/kernel/init_main.c
+init_main.o: $S/kernel/init_main.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-init_sysent.o: $S/kernel/init_sysent.c
+init_sysent.o: $S/kernel/init_sysent.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_clock.o: $S/kernel/kern_clock.c
+kern_clock.o: $S/kernel/kern_clock.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_descrip.o: $S/kernel/kern_descrip.c
+kern_descrip.o: $S/kernel/kern_descrip.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_exec.o: $S/kernel/kern_exec.c
+kern_exec.o: $S/kernel/kern_exec.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_exit.o: $S/kernel/kern_exit.c
+kern_exit.o: $S/kernel/kern_exit.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_fork.o: $S/kernel/kern_fork.c
+kern_fork.o: $S/kernel/kern_fork.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_mman.o: $S/kernel/kern_mman.c
+kern_mman.o: $S/kernel/kern_mman.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_proc.o: $S/kernel/kern_proc.c
+kern_proc.o: $S/kernel/kern_proc.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_prot.o: $S/kernel/kern_prot.c
+kern_prot.o: $S/kernel/kern_prot.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_prot2.o: $S/kernel/kern_prot2.c
+kern_prot2.o: $S/kernel/kern_prot2.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_resource.o: $S/kernel/kern_resource.c
+kern_resource.o: $S/kernel/kern_resource.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_sig.o: $S/kernel/kern_sig.c
+kern_sig.o: $S/kernel/kern_sig.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_sig2.o: $S/kernel/kern_sig2.c
+kern_sig2.o: $S/kernel/kern_sig2.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_subr.o: $S/kernel/kern_subr.c
+kern_subr.o: $S/kernel/kern_subr.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_synch.o: $S/kernel/kern_synch.c
+kern_synch.o: $S/kernel/kern_synch.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_sysctl.o: $S/kernel/kern_sysctl.c
+kern_sysctl.o: $S/kernel/kern_sysctl.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_time.o: $S/kernel/kern_time.c
+kern_time.o: $S/kernel/kern_time.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-subr_prf.o: $S/kernel/subr_prf.c
+subr_prf.o: $S/kernel/subr_prf.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-subr_rmap.o: $S/kernel/subr_rmap.c
+subr_rmap.o: $S/kernel/subr_rmap.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sys_generic.o: $S/kernel/sys_generic.c
+sys_generic.o: $S/kernel/sys_generic.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sys_inode.o: $S/kernel/sys_inode.c
+sys_inode.o: $S/kernel/sys_inode.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sys_pipe.o: $S/kernel/sys_pipe.c
+sys_pipe.o: $S/kernel/sys_pipe.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sys_process.o: $S/kernel/sys_process.c
+sys_process.o: $S/kernel/sys_process.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-syscalls.o: $S/kernel/syscalls.c
+syscalls.o: $S/kernel/syscalls.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-tty.o: $S/kernel/tty.c
+tty.o: $S/kernel/tty.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-tty_subr.o: $S/kernel/tty_subr.c
+tty_subr.o: $S/kernel/tty_subr.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-tty_tty.o: $S/kernel/tty_tty.c
+tty_tty.o: $S/kernel/tty_tty.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_alloc.o: $S/kernel/ufs_alloc.c
+ufs_alloc.o: $S/kernel/ufs_alloc.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_bio.o: $S/kernel/ufs_bio.c
+ufs_bio.o: $S/kernel/ufs_bio.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_bmap.o: $S/kernel/ufs_bmap.c
+ufs_bmap.o: $S/kernel/ufs_bmap.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_dsort.o: $S/kernel/ufs_dsort.c
+ufs_dsort.o: $S/kernel/ufs_dsort.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_fio.o: $S/kernel/ufs_fio.c
+ufs_fio.o: $S/kernel/ufs_fio.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_inode.o: $S/kernel/ufs_inode.c
+ufs_inode.o: $S/kernel/ufs_inode.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_mount.o: $S/kernel/ufs_mount.c
+ufs_mount.o: $S/kernel/ufs_mount.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_namei.o: $S/kernel/ufs_namei.c
+ufs_namei.o: $S/kernel/ufs_namei.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_subr.o: $S/kernel/ufs_subr.c
+ufs_subr.o: $S/kernel/ufs_subr.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_syscalls.o: $S/kernel/ufs_syscalls.c
+ufs_syscalls.o: $S/kernel/ufs_syscalls.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_syscalls2.o: $S/kernel/ufs_syscalls2.c
+ufs_syscalls2.o: $S/kernel/ufs_syscalls2.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-vfs_vnops.o: $S/kernel/vfs_vnops.c
+vfs_vnops.o: $S/kernel/vfs_vnops.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-vm_sched.o: $S/kernel/vm_sched.c
+vm_sched.o: $S/kernel/vm_sched.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-vm_swap.o: $S/kernel/vm_swap.c
+vm_swap.o: $S/kernel/vm_swap.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-vm_swp.o: $S/kernel/vm_swp.c
+vm_swp.o: $S/kernel/vm_swp.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-clock.o: $S/pic32/clock.c
+clock.o: $S/pic32/clock.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-cons.o: $S/pic32/cons.c
+cons.o: $S/pic32/cons.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-devsw.o: $S/pic32/devsw.c
+devsw.o: $S/pic32/devsw.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exception.o: $S/pic32/exception.c
+exception.o: $S/pic32/exception.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-machdep.o: $S/pic32/machdep.c
+machdep.o: $S/pic32/machdep.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-mem.o: $S/pic32/mem.c
+mem.o: $S/pic32/mem.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-signal.o: $S/pic32/signal.c
+signal.o: $S/pic32/signal.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-swap.o: $S/pic32/swap.c
+swap.o: $S/pic32/swap.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sysctl.o: $S/pic32/sysctl.c
+sysctl.o: $S/pic32/sysctl.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-adc.o: $S/pic32/adc.c
+adc.o: $S/pic32/adc.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-gpio.o: $S/pic32/gpio.c
+gpio.o: $S/pic32/gpio.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-pwm.o: $S/pic32/pwm.c
+pwm.o: $S/pic32/pwm.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sd.o: $S/pic32/sd.c
+sd.o: $S/pic32/sd.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-spi.o: $S/pic32/spi.c
+spi.o: $S/pic32/spi.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-spi_bus.o: $S/pic32/spi_bus.c
+spi_bus.o: $S/pic32/spi_bus.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-uart.o: $S/pic32/uart.c
+uart.o: $S/pic32/uart.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
 
-ifeq (.deps, $(wildcard .deps))
 -include .deps/*.dep
-endif

--- a/sys/pic32/olimex/Makefile
+++ b/sys/pic32/olimex/Makefile
@@ -105,35 +105,45 @@ SYSTEM_OBJ      = startup.o ${OBJS} ioconf.o
 ifeq (devcfg.c,$(wildcard devcfg.c))
     SYSTEM_OBJ  += devcfg.o
 endif
-SYSTEM_DEP      = Makefile ioconf.c machine sys .deps ${SYSTEM_OBJ}
+SYSTEM_DEP      = Makefile ioconf.c | machine sys .deps
 SYSTEM_LD_HEAD  = sh ../newvers.sh > vers.c; ${CC} $(CFLAGS) -c vers.c; rm -f $@
 SYSTEM_LD       = -@echo ${LD} ${LDFLAGS} '$${SYSTEM_OBJ}' vers.o -o $@; \
                   ${LD} ${LDFLAGS} ${SYSTEM_OBJ} vers.o -o $@
 SYSTEM_LD_TAIL  = ${SIZE} $@; \
                   $(OBJCOPY) -O ihex $@ $(basename $@).hex; \
                   $(OBJCOPY) -O binary -R .boot -R .config $@ $(basename $@).bin; \
+				  $(OBJCOPY) -O binary --only-section .boot $@ boot.bin; \
                   $(OBJDUMP) -d -S $@ > $(basename $@).dis; \
                   $(NM) -n $@ > $(basename $@).nm
 
 unix: unix.elf
 
-unix.elf: ${SYSTEM_DEP} swapunix.o
+unix.elf: ${SYSTEM_DEP} ${SYSTEM_OBJ} swapunix.o
 	${SYSTEM_LD_HEAD}
 	${SYSTEM_LD} swapunix.o
 	${SYSTEM_LD_TAIL}
 
-swapunix.o: swapunix.c
+swapunix.o: swapunix.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
 all: unix
 
 clean:
-	rm -rf .deps *.elf *.o *.nm *.dis *.bin machine sys
+	rm -rf *.elf *.o *.nm *.dis *.bin
 
 clean-all: clean
-	rm -f *.h *.hex ioconf.c swap*.c vers.c
+	rm -f *.h *.hex ioconf.c swap*.c vers.c machine sys .deps
 
-reconfig ioconf.c: Config ../../../tools/kconfig/kconfig
+.PHONY: reconfig
+
+reconfig: ioconf.c
+
+swapunix.c: Config ../../../tools/kconfig/kconfig | sys machine
+	../../../tools/kconfig/kconfig Config
+	$(MAKE) clean
+	rm -f *.hex
+
+ioconf.c: Config ../../../tools/kconfig/kconfig | sys machine
 	../../../tools/kconfig/kconfig Config
 	$(MAKE) clean
 	rm -f *.hex
@@ -150,214 +160,214 @@ sys:
 .deps:
 	mkdir .deps
 
-startup.o: ../startup.S
+startup.o: ../startup.S ${SYSTEM_DEP}
 	${COMPILE_S}
 
-ioconf.o: ioconf.c
+ioconf.o: ioconf.c  ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exec_aout.o: $S/kernel/exec_aout.c
+devcfg.o: devcfg.c ${SYSTEM_DEP}
+
+exec_aout.o: $S/kernel/exec_aout.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exec_conf.o: $S/kernel/exec_conf.c
+exec_conf.o: $S/kernel/exec_conf.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exec_elf.o: $S/kernel/exec_elf.c
+exec_elf.o: $S/kernel/exec_elf.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exec_script.o: $S/kernel/exec_script.c
+exec_script.o: $S/kernel/exec_script.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exec_subr.o: $S/kernel/exec_subr.c
+exec_subr.o: $S/kernel/exec_subr.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-init_main.o: $S/kernel/init_main.c
+init_main.o: $S/kernel/init_main.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-init_sysent.o: $S/kernel/init_sysent.c
+init_sysent.o: $S/kernel/init_sysent.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_clock.o: $S/kernel/kern_clock.c
+kern_clock.o: $S/kernel/kern_clock.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_descrip.o: $S/kernel/kern_descrip.c
+kern_descrip.o: $S/kernel/kern_descrip.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_exec.o: $S/kernel/kern_exec.c
+kern_exec.o: $S/kernel/kern_exec.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_exit.o: $S/kernel/kern_exit.c
+kern_exit.o: $S/kernel/kern_exit.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_fork.o: $S/kernel/kern_fork.c
+kern_fork.o: $S/kernel/kern_fork.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_mman.o: $S/kernel/kern_mman.c
+kern_mman.o: $S/kernel/kern_mman.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_proc.o: $S/kernel/kern_proc.c
+kern_proc.o: $S/kernel/kern_proc.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_prot.o: $S/kernel/kern_prot.c
+kern_prot.o: $S/kernel/kern_prot.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_prot2.o: $S/kernel/kern_prot2.c
+kern_prot2.o: $S/kernel/kern_prot2.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_resource.o: $S/kernel/kern_resource.c
+kern_resource.o: $S/kernel/kern_resource.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_sig.o: $S/kernel/kern_sig.c
+kern_sig.o: $S/kernel/kern_sig.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_sig2.o: $S/kernel/kern_sig2.c
+kern_sig2.o: $S/kernel/kern_sig2.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_subr.o: $S/kernel/kern_subr.c
+kern_subr.o: $S/kernel/kern_subr.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_synch.o: $S/kernel/kern_synch.c
+kern_synch.o: $S/kernel/kern_synch.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_sysctl.o: $S/kernel/kern_sysctl.c
+kern_sysctl.o: $S/kernel/kern_sysctl.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-kern_time.o: $S/kernel/kern_time.c
+kern_time.o: $S/kernel/kern_time.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-subr_prf.o: $S/kernel/subr_prf.c
+subr_prf.o: $S/kernel/subr_prf.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-subr_rmap.o: $S/kernel/subr_rmap.c
+subr_rmap.o: $S/kernel/subr_rmap.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sys_generic.o: $S/kernel/sys_generic.c
+sys_generic.o: $S/kernel/sys_generic.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sys_inode.o: $S/kernel/sys_inode.c
+sys_inode.o: $S/kernel/sys_inode.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sys_pipe.o: $S/kernel/sys_pipe.c
+sys_pipe.o: $S/kernel/sys_pipe.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sys_process.o: $S/kernel/sys_process.c
+sys_process.o: $S/kernel/sys_process.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-syscalls.o: $S/kernel/syscalls.c
+syscalls.o: $S/kernel/syscalls.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-tty.o: $S/kernel/tty.c
+tty.o: $S/kernel/tty.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-tty_subr.o: $S/kernel/tty_subr.c
+tty_subr.o: $S/kernel/tty_subr.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-tty_tty.o: $S/kernel/tty_tty.c
+tty_tty.o: $S/kernel/tty_tty.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_alloc.o: $S/kernel/ufs_alloc.c
+ufs_alloc.o: $S/kernel/ufs_alloc.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_bio.o: $S/kernel/ufs_bio.c
+ufs_bio.o: $S/kernel/ufs_bio.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_bmap.o: $S/kernel/ufs_bmap.c
+ufs_bmap.o: $S/kernel/ufs_bmap.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_dsort.o: $S/kernel/ufs_dsort.c
+ufs_dsort.o: $S/kernel/ufs_dsort.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_fio.o: $S/kernel/ufs_fio.c
+ufs_fio.o: $S/kernel/ufs_fio.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_inode.o: $S/kernel/ufs_inode.c
+ufs_inode.o: $S/kernel/ufs_inode.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_mount.o: $S/kernel/ufs_mount.c
+ufs_mount.o: $S/kernel/ufs_mount.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_namei.o: $S/kernel/ufs_namei.c
+ufs_namei.o: $S/kernel/ufs_namei.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_subr.o: $S/kernel/ufs_subr.c
+ufs_subr.o: $S/kernel/ufs_subr.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_syscalls.o: $S/kernel/ufs_syscalls.c
+ufs_syscalls.o: $S/kernel/ufs_syscalls.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-ufs_syscalls2.o: $S/kernel/ufs_syscalls2.c
+ufs_syscalls2.o: $S/kernel/ufs_syscalls2.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-vfs_vnops.o: $S/kernel/vfs_vnops.c
+vfs_vnops.o: $S/kernel/vfs_vnops.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-vm_sched.o: $S/kernel/vm_sched.c
+vm_sched.o: $S/kernel/vm_sched.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-vm_swap.o: $S/kernel/vm_swap.c
+vm_swap.o: $S/kernel/vm_swap.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-vm_swp.o: $S/kernel/vm_swp.c
+vm_swp.o: $S/kernel/vm_swp.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-clock.o: $S/pic32/clock.c
+clock.o: $S/pic32/clock.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-cons.o: $S/pic32/cons.c
+cons.o: $S/pic32/cons.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-devsw.o: $S/pic32/devsw.c
+devsw.o: $S/pic32/devsw.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-exception.o: $S/pic32/exception.c
+exception.o: $S/pic32/exception.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-machdep.o: $S/pic32/machdep.c
+machdep.o: $S/pic32/machdep.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-mem.o: $S/pic32/mem.c
+mem.o: $S/pic32/mem.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-signal.o: $S/pic32/signal.c
+signal.o: $S/pic32/signal.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-swap.o: $S/pic32/swap.c
+swap.o: $S/pic32/swap.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sysctl.o: $S/pic32/sysctl.c
+sysctl.o: $S/pic32/sysctl.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-adc.o: $S/pic32/adc.c
+adc.o: $S/pic32/adc.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-gpio.o: $S/pic32/gpio.c
+gpio.o: $S/pic32/gpio.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-pwm.o: $S/pic32/pwm.c
+pwm.o: $S/pic32/pwm.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-sd.o: $S/pic32/sd.c
+sd.o: $S/pic32/sd.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-spi.o: $S/pic32/spi.c
+spi.o: $S/pic32/spi.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-spi_bus.o: $S/pic32/spi_bus.c
+spi_bus.o: $S/pic32/spi_bus.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-uart.o: $S/pic32/uart.c
+uart.o: $S/pic32/uart.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-usb_device.o: $S/pic32/usb_device.c
+usb_device.o: $S/pic32/usb_device.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-usb_function_cdc.o: $S/pic32/usb_function_cdc.c
+usb_function_cdc.o: $S/pic32/usb_function_cdc.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
-usb_uart.o: $S/pic32/usb_uart.c
+usb_uart.o: $S/pic32/usb_uart.c ${SYSTEM_DEP}
 	${COMPILE_C}
 
 
-ifeq (.deps, $(wildcard .deps))
 -include .deps/*.dep
-endif

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,6 +3,8 @@ SUBDIR		= elf2aout fsutil kconfig
 all install depend: ${SUBDIR}
 		-for i in ${SUBDIR}; do ${MAKE} -C $$i ${MFLAGS} DESTDIR=${DESTDIR} $@; done
 
+.PHONY: all
+
 clean:
 		rm -f *~
 		for i in ${SUBDIR}; do ${MAKE} -C $$i ${MFLAGS} clean; done

--- a/tools/kconfig/.gitignore
+++ b/tools/kconfig/.gitignore
@@ -1,2 +1,3 @@
 y.tab.h
 kconfig
+config.c

--- a/tools/kconfig/Makefile
+++ b/tools/kconfig/Makefile
@@ -19,6 +19,12 @@ clean:
 $(PROG):	$(OBJS)
 		$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
 
+config.c: config.y
+	${YACC} config.y
+	mv -f y.tab.c config.c
+
+y.tab.h: config.c
+
 main.o: main.c y.tab.h config.h
 mkheaders.o: mkheaders.c config.h y.tab.h
 mkioconf.o: mkioconf.c y.tab.h config.h

--- a/tools/kconfig/mkmakefile.c
+++ b/tools/kconfig/mkmakefile.c
@@ -377,7 +377,7 @@ void do_rules(FILE *f)
             fprintf(f, "%so:\n\t-cp $S/%so .\n\n", tail(np), np);
             continue;
         }
-        fprintf(f, "%so: $S/%s%c\n", tail(np), np, och);
+        fprintf(f, "%so: $S/%s%c ${SYSTEM_DEP}\n", tail(np), np, och);
         special = ftp->f_special;
         if (special == 0) {
             static char cmd[128];
@@ -392,7 +392,7 @@ void do_rules(FILE *f)
 void do_swapspec(FILE *f, char *name)
 {
     if (!eq(name, "generic"))
-        fprintf(f, "swap%s.o: swap%s.c\n", name, name);
+        fprintf(f, "swap%s.o: swap%s.c ${SYSTEM_DEP}\n", name, name);
     else
         fprintf(f, "swapgeneric.o: $A/%s/swapgeneric.c\n", archname);
     fprintf(f, "\t${COMPILE_C}\n\n");
@@ -402,7 +402,7 @@ struct file_list *do_systemspec(FILE *f, struct file_list *fl, int first)
 {
     fprintf(f, "%s: %s.elf\n\n", fl->f_needs, fl->f_needs);
 
-    fprintf(f, "%s.elf: ${SYSTEM_DEP} swap%s.o", fl->f_needs, fl->f_fn);
+    fprintf(f, "%s.elf: ${SYSTEM_DEP} ${SYSTEM_OBJ} swap%s.o", fl->f_needs, fl->f_fn);
     // Don't use newvers target.
     // A preferred way is to run newvers.sh from SYSTEM_LD_HEAD macro.
     // if (first)


### PR DESCRIPTION
This allow make to be run with the -j option. Tested with -j8 in order to use all the available threads on my machine.

I attempted to keep the changes to the makefiles minimal, adding dependencies as required. I could also do a deeper rework of the makefiles with formatting and organizational changes if preferred, but I think that would be better as a separate PR.

Tested this lightly in the virtualmips simulator. Since this only changes makefiles, there should be little chance of introducing regressions.

Time comparison (5x speedup):
`make  154.81s user 62.56s system 102% cpu 3:31.46 total`
`make -j8  195.79s user 60.50s system 537% cpu 47.725 total`